### PR TITLE
refactor(backup): mejorar script de backup y documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,86 @@
-# mysql-dockerized-backup
+# MySQL Dockerized Backup
 
-[![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=dqmdz&theme=blue-green)](https://github.com/dqmdz/mysql-dockerized-backup)
+A Docker-based tool for backing up MySQL databases with automatic rotation and compression.
+
+## Features
+
+- Backup MySQL databases to compressed `.tar.gz` files
+- Automatic cleanup of old backups based on configured retention days
+- REST API endpoint to trigger backups
+- Configurable via environment variables
+
+## Quick Start
+
+```bash
+# Configure environment variables
+cp .env.example .env
+# Edit .env with your database credentials
+
+# Build and run with Docker Compose
+docker-compose up -d
+```
+
+## Configuration
+
+Configure the following environment variables:
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `DB_HOST` | MySQL server hostname | Yes |
+| `DB_USER` | MySQL username | Yes |
+| `DB_PASSWORD` | MySQL password | Yes |
+| `DAYS` | Number of days to keep backups | Yes |
+
+## Database Selection
+
+Edit the `backup/names` file to specify which databases to backup. Add one database name per line:
+
+```
+database1
+database2
+database3
+```
+
+## Usage
+
+### Trigger a Backup
+
+Make a GET request to the backup endpoint:
+
+```bash
+curl http://localhost:5000/backup
+```
+
+The response will be `"Backup finished"` when complete.
+
+### Backup Output
+
+Backups are saved to the `/app/backup` volume (mapped to `./backup` by default in docker-compose).
+
+Format: `{database_name}{date}.tar.gz`
+
+Example: `haberes20260305.tar.gz`
+
+### Automatic Cleanup
+
+Backups older than the configured `DAYS` value are automatically deleted after each backup run.
+
+## Project Structure
+
+```
+.
+├── app/
+│   ├── __init__.py
+│   ├── app.py          # Flask application
+│   └── task.py         # Backup logic
+├── backup/
+│   └── names           # List of databases to backup
+├── .env.example        # Environment variables template
+├── Dockerfile
+├── docker-compose.yml
+└── requirements.txt
+```
+
+## License
+
+See [LICENSE](LICENSE) file.

--- a/app/task.py
+++ b/app/task.py
@@ -1,55 +1,62 @@
-import os
-import time
 import logging
+import os
+import shlex
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
 
 from dotenv import load_dotenv
-from datetime import datetime, timedelta
 
 
 def make_backup():
-
     load_dotenv()
 
     db_host = os.getenv('DB_HOST')
     db_user = os.getenv('DB_USER')
     db_password = os.getenv('DB_PASSWORD')
     days = int(os.getenv('DAYS'))
-    backup_path = 'backup/'
+    backup_path = Path('backup')
 
-    logging.info(
-        f'host={db_host} - user={db_user} - pwd={db_password} - days={days}')
+    logging.info(f'host={db_host} - user={db_user} - pwd={db_password} - days={days}')
 
-    now = time.strftime('%Y%m%d')
+    now = datetime.now()
+    before = (now - timedelta(days=days)).strftime('%Y%m%d')
+    now_str = now.strftime('%Y%m%d')
 
-    today = datetime.now()
-    delta = timedelta(days=days)
-    previous = today - delta
-    before = previous.strftime('%Y%m%d')
+    db_names = [line.strip() for line in (backup_path / 'names').read_text().splitlines() if line.strip()]
+    logging.info(f'count_db={len(db_names)}')
 
-    file = open("backup/names", 'r')
-    count_db = len(file.readlines())
-    logging.info(f'count_db={count_db}')
-    file.close()
-    p = 1
-    file = open("backup/names", 'r')
-    while p <= count_db:
-        db = file.readline()[:-1]
-        if db.strip() != "":
-            logging.info(f'backup {db}')
-            dumpcmd = "mysqldump -h " + db_host + " -u " + db_user + " -p" + \
-                db_password + " " + db + " > " + backup_path + db + now + ".sql"
-            logging.info(dumpcmd)
-            os.system(dumpcmd)
-            dumpcmd = "tar -zcf " + backup_path + db + now + \
-                ".tar.gz " + backup_path + db + now + ".sql"
-            logging.info(dumpcmd)
-            os.system(dumpcmd)
-            dumpcmd = "rm " + backup_path + db + now + ".sql"
-            logging.info(dumpcmd)
-            os.system(dumpcmd)
-            dumpcmd = "rm " + backup_path + db + before + ".tar.gz"
-            logging.info(dumpcmd)
-            os.system(dumpcmd)
+    for db in db_names:
+        logging.info(f'backup {db}')
+        
+        sql_file = backup_path / f'{db}{now_str}.sql'
+        tar_file = backup_path / f'{db}{now_str}.tar.gz'
+        old_tar = backup_path / f'{db}{before}.tar.gz'
 
-        p = p + 1
-    file.close()
+        dumpcmd = shlex.join([
+            'mysqldump',
+            '-h', db_host,
+            '-u', db_user,
+            f'-p{db_password}',
+            '--single-transaction',
+            '--quick',
+            '--skip-lock-tables',
+            '--skip-add-locks',
+            '--set-gtid-purged=OFF',
+            '--compress',
+            db
+        ]) + f' > {sql_file}'
+        
+        logging.info(dumpcmd)
+        subprocess.run(dumpcmd, shell=True, check=True)
+
+        tar_cmd = ['tar', '-zcf', str(tar_file), str(sql_file)]
+        logging.info(' '.join(tar_cmd))
+        subprocess.run(tar_cmd, check=True)
+
+        sql_file.unlink()
+        
+        if old_tar.exists():
+            logging.info(f'removing {old_tar}')
+            old_tar.unlink()
+            


### PR DESCRIPTION
Se refactoriza el código de backup para usar subprocess en lugar de os.system, pathlib para rutas, y se añaden flags optimizados para mysqldump (--single-transaction, --quick, --compress).

También se actualiza el README con documentación completa del proyecto.